### PR TITLE
Handle passing zero

### DIFF
--- a/lifeclock-v1/functions.cpp
+++ b/lifeclock-v1/functions.cpp
@@ -256,6 +256,7 @@ unsigned long getSecondsTillDeath() {
   time_t t2 = makeTime(tm2);
   // printTime(tm);
   // printTime(tm2);
+  if((int)t2 - (int)t1 < 1) return 0; //Sort of handle negative numbers
   return t2 - t1;
 }
 


### PR DESCRIPTION
Checks if the current date has passed the "death date" and returns zero, blanking the display.

I assume it would work for v2 as well, but I don't have one to test it on.